### PR TITLE
add more instructions on how to build this dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 Changes
+LICENSE
+META.yml
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+inc/
+pm_to_blib

--- a/README
+++ b/README
@@ -3,9 +3,15 @@ POE/Component/Server/SimpleHTTP
 
 INSTALLATION
 
+You will need first to have (or install):
+
+    Module::Install
+    Module::Install::AutoLicense
+    Module::Install::GithubMeta
+
 To install this module type the following:
 
-   perl Makefile.PL
+   perl Makefile.PL # then install prerequisites
    make
    make test
    make install


### PR DESCRIPTION
in the README document that a couple of extra Module::Install mods
are required as a vanilla Module::Install does not support some of
the options in the Makefile.PL

update .gitignore to included (well, exclude) files generated by
the build process
