### PR TITLE
Fix graceful shutdowns when keep-alives are in use

### DIFF
--- a/lib/POE/Component/Server/SimpleHTTP.pm
+++ b/lib/POE/Component/Server/SimpleHTTP.pm
@@ -252,8 +252,10 @@ event 'SHUTDOWN' => sub {
    # Are we gracefully shutting down or not?
    if ( $graceful ) {
 
-      # Check for number of requests
-      if ( keys( %{ $self->_requests } ) == 0 ) {
+      # Check for existing requests and keep-alive connections
+      if ( keys( %{ $self->_requests } ) == 0
+         and keys( %{ $self->_connections } ) == 0 )
+      {
 
          # Alright, shutdown anyway
 


### PR DESCRIPTION
If you shut down the httpd gracefully while there's a keep-alive connection is connected, then any subsequent requests through that connection will result in an error.  This occurs since the as the handler's post to the DONE event will fail due to the alias being removed.
