### PR TITLE
Silence warnings from must_keepalive()

### DIFF
--- a/lib/POE/Component/Server/SimpleHTTP.pm
+++ b/lib/POE/Component/Server/SimpleHTTP.pm
@@ -796,11 +796,11 @@ sub must_keepalive {
    return 0 if $resp->is_error;
 
    # Connection is a comma-seperated header
-   my $conn = lc $req->header('Connection');
+   my $conn = lc ($req->header('Connection') || '');
    return 0 if ",$conn," =~ /,\s*close\s*,/;
-   $conn = lc $req->header('Proxy-Connection');
+   $conn = lc ($req->header('Proxy-Connection') || '');
    return 0 if ",$conn," =~ /,\s*close\s*,/;
-   $conn = lc $resp->header('Connection');
+   $conn = lc ($resp->header('Connection') || '');
    return 0 if ",$conn," =~ /,\s*close\s*,/;
 
    # HTTP/1.1 = keep


### PR DESCRIPTION
A simple patch to silence warnings from must_keepalive().  HTTP::Request->header() (inherited from HTTP::Header->header()) returns undef if the requested header doesn't exist.

Same patch from RT #107397
