### PR TITLE
add support for IPv6

### DIFF
--- a/lib/POE/Component/Server/SimpleHTTP.pm
+++ b/lib/POE/Component/Server/SimpleHTTP.pm
@@ -12,7 +12,7 @@ use POE::Filter::HTTPD;
 use POE::Filter::Stream;
 
 use Carp qw( croak );
-use Socket;
+use Socket qw( AF_INET AF_INET6 INADDR_ANY IN6ADDR_ANY inet_pton );
 
 use HTTP::Date qw( time2str );
 
@@ -38,6 +38,10 @@ use Moose::Util::TypeConstraints;
 
 
 has 'alias' => (
+  is => 'ro',
+);
+
+has 'domain' => (
   is => 'ro',
 );
 
@@ -315,18 +319,39 @@ event 'start_listener' => sub {
 
       $self->inc_retry unless $noinc;
 
+      my $domain = $self->domain;
+      my $bindaddress = $self->address;
+      if ( not defined $bindaddress and not defined $domain ) {
+         $domain = AF_INET6;
+         $bindaddress = IN6ADDR_ANY;
+      } elsif ( not defined $bindaddress ) {
+         if ( $domain == AF_INET6 ) {
+            $bindaddress = IN6ADDR_ANY;
+         } elsif ( $domain == AF_INET ) {
+            $bindaddress = INADDR_ANY;
+         }
+      } else {
+         if ( defined inet_pton(AF_INET6, $bindaddress) ) {
+            $domain = AF_INET6;
+         } elsif ( defined inet_pton(AF_INET, $bindaddress) ) {
+            $domain = AF_INET;
+         }
+      }
+
       # Create our own SocketFactory Wheel :)
       my $factory = POE::Wheel::SocketFactory->new(
+         ( $domain ? ( SocketDomain => $domain ) : () ),
+         ( $bindaddress ? ( BindAddress => $bindaddress ) : () ),
          BindPort     => $self->port,
-         ( $self->address ? ( BindAddress => $self->address ) : () ),
          Reuse        => 'yes',
          SuccessEvent => 'got_connection',
          FailureEvent => 'listener_error',
       );
 
-      my ( $port, $address ) =
-        sockaddr_in( $factory->getsockname );
-      $self->_set_port( $port ) if $self->port == 0;
+      my ( $family, $address, $port, $straddress ) =
+      POE::Component::Server::SimpleHTTP::Connection->get_sockaddr_info(
+         $factory->getsockname );
+      $self->_set_port( $port ) if ( $self->port == 0 and $port );
 
       $self->_set_factory( $factory );
 
@@ -475,8 +500,11 @@ sub MassageHandlers {
 # 'Got_Connection'
 # The actual manager of connections
 event 'got_connection' => sub {
-   my ($kernel,$self,$socket,$peeraddr,$peerport) = @_[KERNEL,OBJECT,ARG0..ARG2];
+   my ( $kernel, $self, $socket ) = @_[KERNEL, OBJECT, ARG0];
 
+   my ( $family, $address, $port, $straddress ) =
+   POE::Component::Server::SimpleHTTP::Connection->get_sockaddr_info(
+      getpeername($socket) );
 
    # Should we SSLify it?
    if ( $self->sslkeycert ) {
@@ -484,9 +512,7 @@ event 'got_connection' => sub {
       # SSLify it!
       eval { $socket = Server_SSLify($socket) };
       if ($@) {
-         warn "Unable to turn on SSL for connection from "
-           . Socket::inet_ntoa( $peeraddr )
-           . " -> $@";
+         warn "Unable to turn on SSL for connection from $straddress -> $@";
          close $socket;
          return 1;
       }
@@ -1367,11 +1393,21 @@ This will default to "SimpleHTTP"
 
 =item C<ADDRESS>
 
-This value will be passed to POE::Wheel::SocketFactory to bind to, will use INADDR_ANY if it is nothing is provided.
+This value will be passed to POE::Wheel::SocketFactory to bind to, will use
+INADDR_ANY if it is nothing is provided (or IN6ADDR_ANY if DOMAIN is AF_INET6).
+For UNIX domain sockets, it should be a path describing the socket's filename.
+
+If neither DOMAIN nor ADDRESS are specified, it will use IN6ADDR_ANY and
+AF_INET6.
 
 =item C<PORT>
 
 This value will be passed to POE::Wheel::SocketFactory to bind to.
+
+=item C<DOMAIN>
+
+This value will be passed to POE::Wheel::SocketFactory to define the socket
+domain used (AF_INET, AF_INET6, AF_UNIX).
 
 =item C<HOSTNAME>
 

--- a/t/02_simple_ipv6
+++ b/t/02_simple_ipv6
@@ -1,0 +1,105 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use POE qw(Component::Server::SimpleHTTP Filter::Stream);
+use Test::POE::Client::TCP;
+use HTTP::Request;
+
+POE::Session->create(
+   package_states => [
+	main => [qw(_start _tests webc_connected webc_input webc_disconnected TOP)],
+   ],
+);
+
+$poe_kernel->run();
+exit 0;
+
+sub _start {
+  my $session_id = $_[SESSION]->ID();
+  diag "starting httpd6";
+  POE::Component::Server::SimpleHTTP->new(
+                'ALIAS'         =>      'HTTPD6',
+                'ADDRESS'       =>      '::1',
+                'PORT'          =>      0,
+                'HOSTNAME'      =>      'pocosimpletest.com',
+                'HANDLERS'      =>      [
+                        {
+                                'DIR'           =>      '^/honk/',
+                                'SESSION'       =>      $session_id,
+                                'EVENT'         =>      'HONK',
+                        },
+                        {
+                                'DIR'           =>      '^/bonk/zip.html',
+                                'SESSION'       =>      $session_id,
+                                'EVENT'         =>      'BONK2',
+                        },
+                        {
+                                'DIR'           =>      '^/bonk/',
+                                'SESSION'       =>      $session_id,
+                                'EVENT'         =>      'BONK',
+                        },
+                        {
+                                'DIR'           =>      '^/$',
+                                'SESSION'       =>      $session_id,
+                                'EVENT'         =>      'TOP',
+                        },
+                ],
+                SETUPHANDLER => { SESSION => $session_id, EVENT => '_tests', },
+  );
+  diag "httpd6 started";
+  return;
+}
+
+sub _tests {
+  my ($kernel,$heap,$sender,$port) = @_[KERNEL,HEAP,SENDER,ARG0];
+  diag "Port is $port";
+  $heap->{webc} = Test::POE::Client::TCP->spawn(
+	address 	=> '::1',
+	port    	=> $port,
+	autoconnect 	=> 1,
+	prefix  	=> 'webc',
+	filter		=> POE::Filter::Stream->new(),
+  );
+  $heap->{port} = $port;
+  return;
+}
+
+sub webc_connected {
+  my ($kernel,$heap) = @_[KERNEL,HEAP];
+  diag "webc_connected";
+  $heap->{webc}->send_to_server("GET / HTTP/1.1\x0D\x0AHost: ::1:$heap->{port}\x0D\x0A\x0D\x0A");
+  return;
+}
+
+sub TOP {
+  my( $request, $response, $dirmatch ) = @_[ ARG0 .. ARG2 ];
+  diag($request->as_string);
+  $response->code( 200 );
+  $response->content('Moo');
+  $poe_kernel->post( $_[SENDER], 'DONE', $response );
+  return;
+}
+
+sub webc_input {
+  my ($heap,$input) = @_[HEAP,ARG0];
+  diag($input);
+  # HTTP/1.1 200 (OK)
+  # Date: Tue, 20 Jan 2009 11:56:35 GMT
+  # Content-Length: 3
+  # Content-Type: text/plain
+  if ( $input =~ /^HTTP/ ) {
+     like  ($input, qr/HTTP\/1.1 200 \(OK\)/, 'HTTP/1.1 200 (OK)' );
+     return;
+  }
+  return;
+}
+
+sub webc_disconnected {
+  my ($heap,$state) = @_[HEAP,STATE];
+  pass($state);
+  $heap->{webc}->shutdown();
+  delete $heap->{webc};
+  $poe_kernel->post( 'HTTPD6', 'SHUTDOWN' );
+  return;
+}


### PR DESCRIPTION

In Debian we are currently applying the following patch to
POE-Component-Server-SimpleHTTP.
We thought you might be interested in it too.

    Description: add support for IPv6
     recognise and support IPv6 addresses, listen on IN6ADDR_ANY by default
     .
     Note the test requres a patched Test::POE::Client::TCP, see
     https://github.com/bingos/test-poe-client-tcp/pull/2
    Author: MartÃ­n Ferrari <tincho@debian.org>
    Author: Damyan Ivanov <dmn@debian.org>

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libpoe-component-server-simplehttp-perl/raw/master/debian/patches/ipv6_support.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
